### PR TITLE
libftd2xx: 0.31.0 -> 0.32.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ documentation = "https://docs.rs/ftdi-mpsse"
 static_assertions = "^1.1.0"
 
 [dev-dependencies]
-libftd2xx = "~0.31.0"
+libftd2xx = "~0.32.0"
 version-sync = "0.9"

--- a/tests/mpsse-macro.rs
+++ b/tests/mpsse-macro.rs
@@ -272,7 +272,7 @@ fn user_abstracted_macro() {
 
         // Everything else handled by libftd2xx crate implementation.
         ($($tokens:tt)*) => {
-            ::ftdi_mpsse::mpsse!($($tokens)*);
+            ::ftdi_mpsse::mpsse!($($tokens)*)
         };
     }
 


### PR DESCRIPTION
Updates & fixes the build failure in #5 