### PR TITLE
ci: swap actions-rs for dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,29 +15,19 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    env:
-      RUSTFLAGS: "-D warnings"
+    env: {"RUSTFLAGS": "-D warnings"}
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: x86_64-unknown-linux-gnu
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
       - run: cargo build
 
   test:
     name: Test
     runs-on: ubuntu-latest
-    env:
-      RUSTFLAGS: "-D warnings"
+    env: {"RUSTFLAGS": "-D warnings"}
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: x86_64-unknown-linux-gnu
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
       - run: cargo test --all-features
 
   clippy:
@@ -45,28 +35,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1.0.7
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          target: x86_64-unknown-linux-gnu
-          override: true
           components: clippy
-      # not using clippy-check due to this issue:
-      # https://github.com/actions-rs/clippy-check/issues/2
       - run: cargo clippy --all-features -- --deny warnings
 
   docs:
     name: docs
     runs-on: ubuntu-latest
-    env:
-      RUSTDOCFLAGS: "-D warnings"
+    env: {"RUSTFLAGS": "-D warnings"}
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: x86_64-unknown-linux-gnu
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
       - run: cargo doc
 
   format:
@@ -74,11 +54,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: stable
-          target: x86_64-unknown-linux-gnu
-          override: true
           components: rustfmt
       - run: cargo fmt -- --check
 
@@ -94,9 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      - uses: dtolnay/rust-toolchain@stable
       - run: cargo publish --token ${CRATES_IO_TOKEN}
         env:
           CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}


### PR DESCRIPTION
`actions-rs` appears to be unmaintained: https://github.com/actions-rs/toolchain/issues/216